### PR TITLE
Fixed unnecessary Promise usage

### DIFF
--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -255,7 +255,10 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                 }
                             };
                             duplexStream._read = function (size) {
-                                sharpInstance.metadata().then(function (metadata) {
+                                sharpInstance.metadata(function (err, metadata) {
+                                    if (err) {
+                                        return duplexStream.emit('error', err);
+                                    }
                                     if (metadata.format) {
                                         // metadata.format is one of 'jpeg', 'png', 'webp' so this should be safe:
                                         metadata.contentType = 'image/' + metadata.format;
@@ -283,8 +286,6 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                     }
                                     duplexStream.push(JSON.stringify(metadata));
                                     duplexStream.push(null);
-                                }, function (err) {
-                                    duplexStream.emit('error', err);
                                 });
                             };
                             duplexStream.on('finish', function () {


### PR DESCRIPTION
If you ran `NODE_ENV=development npm test` you would get this warning from bluebird: 

> Warning: a promise was created in a handler but was not returned from it. 

This PR fixes that.

The problem is that if you're testing some other code that uses express-processimage, this warning bubbles up and can take quite a while to debug :)