### PR TITLE
Browsersync second round

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/lib/processImage.js
+++ b/lib/processImage.js
@@ -60,10 +60,10 @@ module.exports = function (options) {
             hijackResponse(res, function (err, res) {
                 // Polyfill res.status for browser-sync compatibility
                 if (typeof res.status !== 'function') {
-                  res.status = function status(statusCode) {
-                    res.statusCode = statusCode;
-                    return res;
-                  };
+                    res.status = function status(statusCode) {
+                        res.statusCode = statusCode;
+                        return res;
+                    };
                 }
 
                 var sourceMetadata;

--- a/lib/processImage.js
+++ b/lib/processImage.js
@@ -30,8 +30,9 @@ module.exports = function (options) {
         getFilterInfosAndTargetContentTypeFromQueryString.sharp.cache(options.sharpCache);
     }
     return function (req, res, next) {
+        // Polyfill req.accepts for browser-sync compatibility
         if (typeof req.accepts !== 'function') {
-            req.accepts = function () {
+            req.accepts = function requestAccepts() {
                 var accept = accepts(req);
                 return accept.types.apply(accept, arguments);
             };
@@ -57,6 +58,14 @@ module.exports = function (options) {
             }
             delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling processimage
             hijackResponse(res, function (err, res) {
+                // Polyfill res.status for browser-sync compatibility
+                if (typeof res.status !== 'function') {
+                  res.status = function status(statusCode) {
+                    res.statusCode = statusCode;
+                    return res;
+                  };
+                }
+
                 var sourceMetadata;
                 function makeFilterInfosAndTargetFormat() {
                     return getFilterInfosAndTargetContentTypeFromQueryString(queryString, _.defaults({


### PR DESCRIPTION
`res.status` needs to be polyfilled for browser-sync support