### PR TITLE
Permit omitting either the width or the height when resizing again

### DIFF
--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -81,13 +81,14 @@ function isValidOperation(name, args) {
     case 'rotate':
         return args.length === 0 || (args.length === 1 && (args[0] === 0 || args[0] === 90 || args[0] === 180 || args[0] === 270));
     case 'resize':
+        if (args.length === 1 || (args.length === 2 && args[1] === '')) {
+            return isNumberWithin(args[0], 1, maxDimension);
+        }
         if (args.length !== 2) {
             return false;
         }
         if (args[0] === '') {
             return isNumberWithin(args[1], 1, maxDimension);
-        } else if (args[1] === '') {
-            return isNumberWithin(args[0], 1, maxDimension);
         }
         return isNumberWithin(args[0], 1, maxDimension) && isNumberWithin(args[1], 1, maxDimension);
     case 'extract':

--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -81,7 +81,15 @@ function isValidOperation(name, args) {
     case 'rotate':
         return args.length === 0 || (args.length === 1 && (args[0] === 0 || args[0] === 90 || args[0] === 180 || args[0] === 270));
     case 'resize':
-        return args.length === 2 && isNumberWithin(args[0], 1, maxDimension) && isNumberWithin(args[1], 1, maxDimension);
+        if (args.length !== 2) {
+            return false;
+        }
+        if (args[0] === '') {
+            return isNumberWithin(args[1], 1, maxDimension);
+        } else if (args[1] === '') {
+            return isNumberWithin(args[0], 1, maxDimension);
+        }
+        return isNumberWithin(args[0], 1, maxDimension) && isNumberWithin(args[1], 1, maxDimension);
     case 'extract':
         return args.length === 4 && isNumberWithin(args[0], 0, maxDimension - 1) && isNumberWithin(args[1], 0, maxDimension - 1) && isNumberWithin(args[2], 1, maxDimension) && isNumberWithin(args[3], 1, maxDimension);
     case 'interpolateWith':
@@ -431,10 +439,16 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
 
                         operations.forEach(function (operation) {
                             if (operation.name === 'resize') {
-                                if (operations.some(function (operation) { return operation.name === 'ignoreAspectRatio'; })) {
-                                    gifsicleArgs.push('--resize', operation.args[0] + 'x' + operation.args[1]);
+                                if (operation.args[0] === undefined) {
+                                    gifsicleArgs.push('--resize-height', operation.args[1]);
+                                } else if (operation.args[1] === undefined) {
+                                    gifsicleArgs.push('--resize-width', operation.args[0]);
                                 } else {
-                                    gifsicleArgs.push('--resize-fit', operation.args[0] + 'x' + operation.args[1]);
+                                    if (operations.some(function (operation) { return operation.name === 'ignoreAspectRatio'; })) {
+                                        gifsicleArgs.push('--resize', operation.args[0] + 'x' + operation.args[1]);
+                                    } else {
+                                        gifsicleArgs.push('--resize-fit', operation.args[0] + 'x' + operation.args[1]);
+                                    }
                                 }
                                 seenOperationThatMustComeBeforeExtract = true;
                             } else if (operation.name === 'extract') {
@@ -650,6 +664,20 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
             if (!isValidOperation(operationName, operationArgs) || (typeof options.allowOperation === 'function' && !options.allowOperation(operationName, operationArgs))) {
                 leftOverQueryStringFragments.push(keyValuePair);
             } else {
+                if (operationName === 'resize') {
+                    if (typeof options.maxOutputPixels === 'number') {
+                        if (operationArgs[0] === '') {
+                            operationArgs[0] = Math.floor(options.maxOutputPixels / operationArgs[1]);
+                        } else if (operationArgs[1] === '') {
+                            operationArgs[1] = Math.floor(options.maxOutputPixels / operationArgs[0]);
+                        }
+                    } else {
+                        operationArgs = operationArgs.map(function (arg) {
+                            return arg === '' ? undefined : arg;
+                        });
+                    }
+                }
+
                 var filterInfo;
                 if (filters[operationName]) {
                     flushOperations();

--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -551,18 +551,24 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                         ignoreAspectRatio = gmOperation;
                                     }
                                 }
-                                if (withoutEnlargement && resize) {
-                                    resize.args[1] += '>';
-                                }
-                                if (ignoreAspectRatio && resize) {
-                                    resize.args[1] += '!';
-                                }
-                                if (resize && crop) {
-                                    gmOperationsForThisInstance.push({
-                                        name: 'extent',
-                                        args: [].concat(resize.args)
-                                    });
-                                    resize.args.push('^');
+                                if (resize) {
+                                    var flags = '';
+                                    if (withoutEnlargement) {
+                                        flags += '>';
+                                    }
+                                    if (ignoreAspectRatio) {
+                                        flags += '!';
+                                    }
+                                    if (crop) {
+                                        gmOperationsForThisInstance.push({
+                                            name: 'extent',
+                                            args: [].concat(resize.args)
+                                        });
+                                        flags += '^';
+                                    }
+                                    if (flags.length > 0) {
+                                        resize.args.push(flags);
+                                    }
                                 }
                                 gmOperationsForThisInstance.reduce(function (gmInstance, gmOperation) {
                                     checkSharpOrGmOperation(gmOperation);
@@ -600,7 +606,12 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                         gmOperation.name = 'setFormat';
                                     }
                                     if (typeof gmInstance[gmOperation.name] === 'function') {
-                                        return gmInstance[gmOperation.name].apply(gmInstance, gmOperation.args);
+                                        if (gmOperation.name === 'resize' && gmOperation.args[1] === undefined) {
+                                            // gm 1.3.18 does not support `-resize 500x` so make sure we omit the x:
+                                            return gmInstance.out('-resize', gmOperation.args[0] + (gmOperation[2] || ''));
+                                        } else {
+                                            return gmInstance[gmOperation.name].apply(gmInstance, gmOperation.args);
+                                        }
                                     } else {
                                         return gmInstance;
                                     }

--- a/test/processImage.js
+++ b/test/processImage.js
@@ -91,6 +91,60 @@ describe('express-processimage', function () {
             });
         });
 
+        describe('when omitting the height', function () {
+            it('should do a proportional resize to the given width', function () {
+                return expect('GET /turtle.jpg?resize=500,', 'to yield response', {
+                    body: expect.it('to have metadata satisfying', {
+                        size: {
+                            width: 500,
+                            height: 441
+                        }
+                    })
+                });
+            });
+
+            describe('with a maxOutputPixels setting in place', function () {
+                it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                    config.maxOutputPixels = 250000;
+                    return expect('GET /turtle.jpg?resize=2000,', 'to yield response', {
+                        body: expect.it('to have metadata satisfying', {
+                            size: {
+                                width: 142,
+                                height: 125
+                            }
+                        })
+                    });
+                });
+            });
+        });
+
+        describe('when omitting the width', function () {
+            it('should do a proportional resize to the given height', function () {
+                return expect('GET /turtle.jpg?resize=,500', 'to yield response', {
+                    body: expect.it('to have metadata satisfying', {
+                        size: {
+                            width: 567,
+                            height: 500
+                        }
+                    })
+                });
+            });
+
+            describe('with a maxOutputPixels setting in place', function () {
+                it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                    config.maxOutputPixels = 250000;
+                    return expect('GET /turtle.jpg?resize=,2000', 'to yield response', {
+                        body: expect.it('to have metadata satisfying', {
+                            size: {
+                                width: 125,
+                                height: 110
+                            }
+                        })
+                    });
+                });
+            });
+        });
+
         it('should do an entropy-based crop', function () {
             return expect('GET /turtle.jpg?resize=100,200&crop=entropy', 'to yield response', {
                 body: expect.it('to resemble', pathModule.resolve(__dirname, '..', 'testdata', 'turtleCroppedEntropy100x200.jpg'))
@@ -759,6 +813,60 @@ describe('express-processimage', function () {
                 body: expect.it('to resemble', pathModule.resolve(__dirname, '..', 'testdata', 'turtleCroppedNorthEastGm.jpg'))
             });
         });
+
+        describe('when omitting the height', function () {
+            it('should do a proportional resize to the given width', function () {
+                return expect('GET /turtle.jpg?gm&resize=500,', 'to yield response', {
+                    body: expect.it('to have metadata satisfying', {
+                        size: {
+                            width: 500,
+                            height: 441
+                        }
+                    })
+                });
+            });
+
+            describe('with a maxOutputPixels setting in place', function () {
+                it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                    config.maxOutputPixels = 250000;
+                    return expect('GET /turtle.jpg?gm&resize=2000,', 'to yield response', {
+                        body: expect.it('to have metadata satisfying', {
+                            size: {
+                                width: 142,
+                                height: 125
+                            }
+                        })
+                    });
+                });
+            });
+        });
+
+        describe('when omitting the width', function () {
+            it('should do a proportional resize to the given height', function () {
+                return expect('GET /turtle.jpg?gm&resize=,500', 'to yield response', {
+                    body: expect.it('to have metadata satisfying', {
+                        size: {
+                            width: 567,
+                            height: 500
+                        }
+                    })
+                });
+            });
+
+            describe('with a maxOutputPixels setting in place', function () {
+                it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                    config.maxOutputPixels = 250000;
+                    return expect('GET /turtle.jpg?gm&resize=,2000', 'to yield response', {
+                        body: expect.it('to have metadata satisfying', {
+                            size: {
+                                width: 125,
+                                height: 110
+                            }
+                        })
+                    });
+                });
+            });
+        });
     });
 
     describe('with a GIF', function () {
@@ -892,6 +1000,60 @@ describe('express-processimage', function () {
                             Interlace: 'Line'
                         })
                         .and('when converted to PNG to resemble', pathModule.resolve(__dirname, '..', 'testdata', 'rotatedBulb.png'))
+                    });
+                });
+
+                describe('when omitting the width', function () {
+                    it('should do a proportional resize to the given height', function () {
+                        return expect('GET /bulb.gif?resize=20,', 'to yield response', {
+                            body: expect.it('to have metadata satisfying', {
+                                size: {
+                                    width: 20,
+                                    height: 20
+                                }
+                            })
+                        });
+                    });
+
+                    describe('with a maxOutputPixels setting in place', function () {
+                        it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                            config.maxOutputPixels = 1000;
+                            return expect('GET /bulb.gif?resize=40,', 'to yield response', {
+                                body: expect.it('to have metadata satisfying', {
+                                    size: {
+                                        width: 25,
+                                        height: 25
+                                    }
+                                })
+                            });
+                        });
+                    });
+                });
+
+                describe('when omitting the height', function () {
+                    it('should do a proportional resize to the given width', function () {
+                        return expect('GET /bulb.gif?resize=,25', 'to yield response', {
+                            body: expect.it('to have metadata satisfying', {
+                                size: {
+                                    width: 25,
+                                    height: 25
+                                }
+                            })
+                        });
+                    });
+
+                    describe('with a maxOutputPixels setting in place', function () {
+                        it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
+                            config.maxOutputPixels = 1000;
+                            return expect('GET /bulb.gif?resize=,40', 'to yield response', {
+                                body: expect.it('to have metadata satisfying', {
+                                    size: {
+                                        width: 25,
+                                        height: 25
+                                    }
+                                })
+                            });
+                        });
                     });
                 });
             });

--- a/test/processImage.js
+++ b/test/processImage.js
@@ -103,6 +103,19 @@ describe('express-processimage', function () {
                 });
             });
 
+            describe('without a trailing comma', function () {
+                it('should do a proportional resize to the given width', function () {
+                    return expect('GET /turtle.jpg?resize=500', 'to yield response', {
+                        body: expect.it('to have metadata satisfying', {
+                            size: {
+                                width: 500,
+                                height: 441
+                            }
+                        })
+                    });
+                });
+            });
+
             describe('with a maxOutputPixels setting in place', function () {
                 it('should limit the size of the bounding box based on the maxOutputPixels value', function () {
                     config.maxOutputPixels = 250000;


### PR DESCRIPTION
If a `maxOutputPixels` setting is in effect, divide it by the dimension that was specified to get the other bounding box dimension.

Implemented and tested for the sharp, gm, and gifsicle engines.