### PR TITLE
?metadata: Populate orientedWidth and orientedHeight based on the image.Orientation EXIF tag

### DIFF
--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -781,6 +781,17 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                             }
                                             metadata.exif = undefined;
                                             if (exifData) {
+                                                const orientation = exifData.image && exifData.image.Orientation;
+                                                // Check if the image.Orientation EXIF tag specifies says that the
+                                                // width and height are to be flipped
+                                                // http://sylvana.net/jpegcrop/exif_orientation.html
+                                                if (typeof orientation === 'number' && orientation >= 5 && orientation <= 8) {
+                                                    metadata.orientedWidth = metadata.height;
+                                                    metadata.orientedHeight = metadata.width;
+                                                } else {
+                                                    metadata.orientedWidth = metadata.width;
+                                                    metadata.orientedHeight = metadata.height;
+                                                }
                                                 _.defaults(metadata, exifData);
                                             }
                                         }

--- a/test/processImage.js
+++ b/test/processImage.js
@@ -662,6 +662,17 @@ describe('express-processimage', function () {
             });
         });
 
+        it('should include orientedWidth and orientedHeight properties when the EXIF data specifies an orientation', function () {
+            return expect('GET /exifOriented.jpg?metadata', 'to yield response', {
+                body: {
+                    width: 3264,
+                    height: 2448,
+                    orientedWidth: 2448,
+                    orientedHeight: 3264
+                }
+            });
+        });
+
         it('should auto-orient an image', function () {
             return expect('GET /exifOriented.jpg?rotate', 'to yield response', {
                 body: expect.it('to have metadata satisfying', {


### PR DESCRIPTION
See https://github.com/lovell/sharp/issues/1139

Some applications might already assume that the `width` and `height` metadata properties correspond to the auto-oriented dimensions.

// CC: @paras20xx
