### PR TITLE
Support setFormat across both sharp and gm.

### DIFF
--- a/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/lib/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -56,7 +56,7 @@ try {
 var sharpFormats = ['png', 'jpeg', 'webp'];
 if (sharp) {
     isOperationByEngineNameAndName.sharp = {};
-    ['resize', 'extract', 'sequentialRead', 'crop', 'max', 'background', 'embed', 'flatten', 'rotate', 'flip', 'flop', 'withoutEnlargement', 'ignoreAspectRatio', 'sharpen', 'interpolateWith', 'gamma', 'grayscale', 'greyscale', 'jpeg', 'png', 'webp', 'quality', 'progressive', 'withMetadata', 'compressionLevel'].forEach(function (sharpOperationName) {
+    ['resize', 'extract', 'sequentialRead', 'crop', 'max', 'background', 'embed', 'flatten', 'rotate', 'flip', 'flop', 'withoutEnlargement', 'ignoreAspectRatio', 'sharpen', 'interpolateWith', 'gamma', 'grayscale', 'greyscale', 'jpeg', 'png', 'webp', 'quality', 'progressive', 'withMetadata', 'compressionLevel', 'setFormat'].forEach(function (sharpOperationName) {
         isOperationByEngineNameAndName.sharp[sharpOperationName] = true;
     });
 }
@@ -410,19 +410,21 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                 create: function () {
                     var sourceContentType = (this.operations[0] && this.operations[0].sourceContentType) || sourceMetadata.contentType;
                     if (sourceContentType === 'image/gif' && !this.operations.some(function (operation) {
-                        return operation.name === 'png' || operation.name === 'webp' || operation.name === 'jpeg';
+                        return operation.name === 'setFormat' && sharpFormats.indexOf(operation.args[0]) > -1;
                     })) {
                         engineName = 'gm';
                         // Gotcha: gifsicle does not support --resize-fit in a way where the image will be enlarged
                         // to fit the bounding box, so &withoutEnlargement is assumed, but not required:
                         // Raised the issue here: https://github.com/kohler/gifsicle/issues/67
                         if (filters.gifsicle !== false && Gifsicle && this.operations.every(function (operation) {
-                            return operation.name === 'resize' || operation.name === 'extract' || operation.name === 'rotate' || operation.name === 'withoutEnlargement' || operation.name === 'progressive' || operation.name === 'crop' || operation.name === 'ignoreAspectRatio';
+                            return operation.name === 'resize' || operation.name === 'extract' || operation.name === 'rotate' || operation.name === 'withoutEnlargement' || operation.name === 'progressive' || operation.name === 'crop' || operation.name === 'ignoreAspectRatio' || (operation.name === 'setFormat' && operation.args[0] === 'gif');
                         })) {
                             engineName = 'gifsicle';
                         }
                     }
-                    this.targetContentType = this.targetContentType || sourceContentType;
+
+                    this.targetContentType = this.outputContentType || targetContentType || sourceContentType;
+
                     var operations = this.operations;
                     this.operationName = engineName;
                     operationNames[operationIndex] = engineName;
@@ -508,6 +510,11 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                         sharpOperationsForThisInstance.forEach(function (operation) {
                             checkSharpOrGmOperation(operation);
                             var args = operation.args;
+                            // Support setFormat operation
+                            if (operation.name === 'setFormat' && args.length === 1) {
+                                operation.name = args[0]; // use the argument as the target format
+                                args = [];
+                            }
                             // Compensate for https://github.com/lovell/sharp/issues/276
                             if (operation.name === 'extract' && args.length >= 4) {
                                 args = [ { left: args[0], top: args[1], width: args[2], height: args[3] } ];
@@ -598,12 +605,6 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                                     if (gmOperation.name === 'progressive') {
                                         gmOperation.name = 'interlace';
                                         gmOperation.args = [ 'line' ];
-                                    }
-                                    // There are many, many more that could be supported:
-                                    if (gmOperation.name === 'webp' || gmOperation.name === 'png' || gmOperation.name === 'jpeg' || gmOperation.name === 'gif') {
-                                        gmOperation = _.extend({}, gmOperation);
-                                        gmOperation.args.unshift(gmOperation.name);
-                                        gmOperation.name = 'setFormat';
                                     }
                                     if (typeof gmInstance[gmOperation.name] === 'function') {
                                         if (gmOperation.name === 'resize' && gmOperation.args[1] === undefined) {
@@ -856,14 +857,23 @@ module.exports = function getFilterInfosAndTargetContentTypeFromQueryString(quer
                             }
                         }
                         var sourceContentType = targetContentType;
+                        var targetFormat;
                         if (operationName === 'setFormat' && operationArgs.length > 0) {
-                            var targetFormat = operationArgs[0].toLowerCase();
+                            targetFormat = operationArgs[0].toLowerCase();
                             if (targetFormat === 'jpg') {
                                 targetFormat = 'jpeg';
                             }
-                            targetContentType = 'image/' + targetFormat;
                         } else if (operationName === 'jpeg' || operationName === 'png' || operationName === 'webp') {
-                            targetContentType = 'image/' + operationName;
+                            targetFormat = operationName;
+                            operationName = 'setFormat';
+                        }
+                        if (targetFormat) {
+                            operationArgs = [targetFormat];
+                            targetContentType = 'image/' + targetFormat;
+                            // fallback to another engine if the requested format is not supported by sharp
+                            if (currentEngineName === 'sharp' && sharpFormats.indexOf(targetFormat) === -1) {
+                                currentEngineName = 'gm';
+                            }
                         }
                         operations.push({sourceContentType: sourceContentType, name: operationName, args: operationArgs, usedQueryStringFragment: keyValuePair});
                         usedQueryStringFragments.push(keyValuePair);

--- a/test/getFilterInfosAndTargetContentTypeFromQueryString.js
+++ b/test/getFilterInfosAndTargetContentTypeFromQueryString.js
@@ -5,23 +5,22 @@ var expect = require('unexpected');
 
 describe('getFilterInfosAndTargetContentTypeFromQueryString', function () {
     it('should make the right engine choice even if the source Content-Type is not available until filterInfo.create is called', function () {
-        var sourceMetadata = {};
         var filterInfosAndTargetContentTypeFromQueryString = getFilterInfosAndTargetContentTypeFromQueryString('resize=10,10', {
-            sourceMetadata: sourceMetadata
+            sourceMetadata: {
+                contentType: 'image/gif'
+            }
         });
-
-        sourceMetadata.contentType = 'image/gif';
 
         filterInfosAndTargetContentTypeFromQueryString.filterInfos[0].create();
 
         expect(filterInfosAndTargetContentTypeFromQueryString, 'to satisfy', {
             operationNames: [ 'gifsicle' ],
-            filterInfos: {
-                0: {
+            filterInfos: [
+                {
                     targetContentType: 'image/gif',
                     operationName: 'gifsicle'
                 }
-            }
+            ]
         });
     });
 
@@ -103,6 +102,52 @@ describe('getFilterInfosAndTargetContentTypeFromQueryString', function () {
                         leftOverQueryStringFragments: undefined
                     }
                 ]
+            });
+        });
+    });
+
+    describe('sharp', function () {
+        it('should allow using setFormat to specify the output format', function () {
+            var filterInfosAndTargetContentTypeFromQueryString = getFilterInfosAndTargetContentTypeFromQueryString('setFormat=png', {
+                defaultEngineName: 'sharp',
+                sourceMetadata: {
+                    contentType: 'image/jpeg'
+                }
+            });
+
+            filterInfosAndTargetContentTypeFromQueryString.filterInfos[0].create();
+
+            expect(filterInfosAndTargetContentTypeFromQueryString, 'to satisfy', {
+                targetContentType: 'image/png',
+                operationNames: [ 'sharp' ],
+                filterInfos: [
+                    {
+                        operationName: 'sharp'
+                    }
+                ]
+            });
+        });
+
+        describe('with a conversion to image/gif', function () {
+            it('should fall back to another engine', function () {
+                var filterInfosAndTargetContentTypeFromQueryString = getFilterInfosAndTargetContentTypeFromQueryString('setFormat=gif', {
+                    defaultEngineName: 'sharp',
+                    sourceMetadata: {
+                        contentType: 'image/jpeg'
+                    }
+                });
+
+                filterInfosAndTargetContentTypeFromQueryString.filterInfos[0].create();
+
+                expect(filterInfosAndTargetContentTypeFromQueryString, 'to satisfy', {
+                    targetContentType: 'image/gif',
+                    operationNames: [ 'gm' ],
+                    filterInfos: [
+                        {
+                            operationName: 'gm'
+                        }
+                    ]
+                });
             });
         });
     });


### PR DESCRIPTION
This patch allows the output format to be specified as a string for
both these engines. This commit also somewhat standardises on the
specification of output type via "setFormat" - convert named formats
On the query string for sharp while in the case of gm remove a wad
Of data shuffling code which is no longer required given it’s native
support of the operation.