### PR TITLE
Travis: Try to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
-  - "9"
+  - '6'
+  - '8'
+  - '9'
 env:
   - CXX=g++-4.8
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
-before_install: "sudo apt-get update && sudo apt-get install -y optipng pngcrush pngquant graphicsmagick libjpeg-turbo-progs inkscape libcairo2-dev libgif-dev libjpeg8-dev"
-script: "npm run-script travis"
+      - g++-4.8
+before_install: 'sudo apt-get update && sudo apt-get install -y optipng pngcrush pngquant graphicsmagick libjpeg-turbo-progs inkscape libcairo2-dev libgif-dev libjpeg8-dev zlib1g-dev'
+script: 'npm run-script travis'


### PR DESCRIPTION
  Error: /lib/x86_64-linux-gnu/libz.so.1: version `ZLIB_1.2.9' not found (required by /home/travis/build/papandreou/express-processimage/node_modules/sharp/build/Release/../../vendor/lib/libpng16.so.16)