### PR TITLE
Add docker development container based on Travis CI setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+# Docker development environment for express-processimage
+#
+# This Dockerfile is for development only.
+#
+# It is built to closely resemble the Travis CI environment, to make the
+# development experience as flawless as possible.
+#
+# Based on https://github.com/creationix/nvm/blob/a1abfd1fe42308599b77461eb15460427fe05b9e/Dockerfile#L16
+
+FROM ubuntu:14.04
+LABEL maintainer="Gustav Nikolaj <gustavnikolaj@gmail.com>"
+LABEL name="express-processimage-dev"
+LABEL version="latest"
+
+# Set the SHELL to bash with pipefail option
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Prevent dialog during apt install
+ENV DEBIAN_FRONTEND noninteractive
+
+# Pick a Ubuntu apt mirror site for better speed
+# ref: https://launchpad.net/ubuntu/+archivemirrors
+ENV UBUNTU_APT_SITE mirror.one.com
+
+# Disable src package source
+RUN sed -i 's/^deb-src\ /\#deb-src\ /g' /etc/apt/sources.list
+
+# Replace origin apt package site with the mirror site
+RUN sed -E -i "s/([a-z]+.)?archive.ubuntu.com/$UBUNTU_APT_SITE/g" /etc/apt/sources.list
+RUN sed -i "s/security.ubuntu.com/$UBUNTU_APT_SITE/g" /etc/apt/sources.list
+
+# Install apt packages
+RUN apt-get update && \
+  apt-get install -y \
+    git \
+    wget \
+    optipng \
+    pngcrush \
+    pngquant \
+    graphicsmagick \
+    libjpeg-turbo-progs \
+    inkscape \
+    libcairo2-dev \
+    libgif-dev \
+    libjpeg8-dev \
+    zlib1g-dev
+
+# Set locale
+RUN locale-gen en_US.UTF-8
+
+# Add user "nvm" as non-root user
+RUN useradd -ms /bin/bash nvm
+
+# Set sudoer for "nvm"
+RUN echo 'nvm ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+# Switch to user "nvm" from now
+USER nvm
+
+# nvm
+RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+
+# Set WORKDIR to nvm directory
+WORKDIR /home/nvm/express-processimage
+
+# Install node version 8 (keep in sync with .travis.yml)
+RUN bash -c 'source $HOME/.nvm/nvm.sh && nvm install 8'
+
+ENTRYPOINT ["/bin/bash"]
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ The `root` option is used by <a
 href="https://github.com/papandreou/node-svgfilter">node-svgfilter</a>
 for finding the location of external JavaScript files to run on the SVG document.
 
+Development with Docker
+-----------------------
+
+Build the docker image by running:
+
+```
+$ npm run docker:build
+```
+
+Open the development environment:
+
+```
+$ npm run docker
+```
+
+The above command will place you in a bash shell where the working directory is
+your express-processimage checkout from your local machine. It is mounted into
+the container which is based on Ubuntu 14.04 and contains all the required
+dependencies, and nvm with the latest node 8 version active.
+
+If you need to run the tests against another node version, you just have to
+change the version using nvm and reinstall your modules.
+
+The environment is configured to resemble our setup on Travis CI as much as
+possible.
+
 License
 -------
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "unexpected-sinon": "^10.10.1"
   },
   "scripts": {
+    "docker:build": "docker build -t express-processimage-dev .",
+    "docker": "docker run --rm -it -v \"$(pwd):/home/nvm/express-processimage\" express-processimage-dev",
     "lint": "eslint . && prettier --check '**/*.js'",
     "test": "mocha && npm run lint",
     "travis": "npm test && npm run coverage && (<coverage/lcov.info coveralls || true)",


### PR DESCRIPTION
I couldn't get my macbook configured to run the tests without failures. This docker container mimics the Travis CI setup and has a completely passing test suite.