### PR TITLE
Fix failing test on node 10

### DIFF
--- a/test/processImage.js
+++ b/test/processImage.js
@@ -1391,6 +1391,9 @@ describe('express-processimage', () => {
           );
         })
         .then(() => {
+          return new Promise(resolve => setTimeout(resolve, 10));
+        })
+        .then(() => {
           expect(createdStreams[0].destroy, 'was called once');
         })
         .finally(() => {


### PR DESCRIPTION
Adding delay before checking if destroy was called is necessary for a passing test on node.js 10.15.2.

It seems that it still works, but that it's just delayed a bit.

Fixes #70 