### PR TITLE
Added support for configuring 'failOnError' for Sharp engine via 'impro'

### DIFF
--- a/lib/processImage.js
+++ b/lib/processImage.js
@@ -234,6 +234,7 @@ module.exports = (options) => {
                 maxInputPixels: options.maxInputPixels,
                 maxOutputPixels: options.maxOutputPixels,
                 sharpCache: options.sharpCache,
+                sharpFailOnError: options.sharpFailOnError,
                 svgAssetPath: options.root
                   ? Path.resolve(options.root, req.url.substr(1))
                   : null,


### PR DESCRIPTION
This change is useful in combination with PR https://github.com/papandreou/impro/pull/5

Copying the description from that pull request:

> For allowing/blocking some corrupt images, one may want to configure `failOnError` option of the Sharp library.
> eg: Some Samsung devices may generate partially invalid JPEG files. Reference: https://github.com/lovell/sharp/issues/1578