### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/papandreou/express-processimage.git"
+    "url": "git+https://github.com/papandreou/express-processimage.git"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
## Summary
- update package repository metadata from the unauthenticated `git://` protocol to `git+https://`
- keep the repository target unchanged: `papandreou/express-processimage`

## Validation
- parsed `package.json` and verified `repository.url`
- `git diff --check`
- `git ls-remote https://github.com/papandreou/express-processimage.git HEAD`

This is metadata-only and does not change runtime code, dependencies, or package behavior.